### PR TITLE
Use http-core semantics, fix refs

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -62,8 +62,8 @@ requires an explicit way of communicating service status and
 usage quotas.
 
 This was partially addressed with the `Retry-After` header field
-defined in {{!SEMANTICS=RFC7231}} to be returned in `429 Too Many Requests` or
-`503 Service Unavailable` responses.
+defined in {{!SEMANTICS=I-D.ietf-httpbis-semantics}} to be returned in
+`429 Too Many Requests` or `503 Service Unavailable` responses.
 
 Still, there is not a standard way to communicate service quotas
 so that the client can throttle its requests
@@ -137,7 +137,7 @@ This proposal defines syntax and semantics for the following fields:
 - `RateLimit-Remaining`: containing the remaining requests quota in the current window;
 - `RateLimit-Reset`: containing the time remaining in the current window, specified in seconds.
 
-The behavior of `RateLimit-Reset` is compatible with the `delta-seconds` notation of `Retry-After`.
+The behavior of `RateLimit-Reset` is compatible with the `delay-seconds` notation of `Retry-After`.
 
 The fields definition allows to describe complex policies, including the ones
 using multiple and variable time windows and dynamic quotas, or implementing concurrency limits.
@@ -187,11 +187,11 @@ The goals do not include:
 
 This document uses the Augmented BNF defined in {{!RFC5234}} and updated
 by {{!RFC7405}} along with the "#rule" extension
-defined {{!MESSAGING=RFC7230}}, Section 7.
+defined {{SEMANTICS}}, Section 5.6.1.
 
 The term Origin is to be interpreted as described in {{!RFC6454}}, Section 7.
 
-The "delta-seconds" rule is defined in {{CACHING}}, Section 1.2.1.
+The "delay-seconds" rule is defined in {{SEMANTICS}}, Section 10.2.4.
 
 # Expressing rate-limit policies
 
@@ -201,7 +201,7 @@ Rate limit policies limit the number of acceptable requests in a given time wind
 
 A time window is expressed in seconds, using the following syntax:
 
-    time-window = delta-seconds
+    time-window = delay-seconds
 
 Subsecond precision is not supported.
 
@@ -353,13 +353,13 @@ The `RateLimit-Reset` response field indicates either
 The header value is
 
 ~~~
-   RateLimit-Reset = delta-seconds
+   RateLimit-Reset = delay-seconds
 ~~~
 
-The delta-seconds format is used because:
+The delay-seconds format is used because:
 
 - it does not rely on clock synchronization and is resilient to clock adjustment
-  and clock skew between client and server (see {{SEMANTICS}}, Section 4.1.1.1);
+  and clock skew between client and server (see {{SEMANTICS}}, Section 5.6.7);
 - it mitigates the risk related to thundering herd when too many clients are serviced with the same timestamp.
 
 This header MUST NOT occur multiple times
@@ -417,7 +417,8 @@ in a trailer section.
 
 # Intermediaries {#intermediaries}
 
-This section documents the considerations advised in Section 15.3.3 of {{SEMANTICS}}.
+This section documents the considerations advised in
+{{SEMANTICS}}, Section 16.3.3.
 
 An intermediary that is not part of the originating service infrastructure
 and is not aware of the quota-policy semantic used by the Origin Server
@@ -1082,15 +1083,14 @@ At this point you should stop increasing your request rate.
 
    I'm open to suggestions: comment on [this issue](https://github.com/ioggstream/draft-polli-ratelimit-headers/issues/70)
 
-5. Why using delta-seconds instead of a UNIX Timestamp?
+5. Why using delay-seconds instead of a UNIX Timestamp?
    Why not using subsecond precision?
 
-   Using delta-seconds aligns with `Retry-After`, which is returned in similar contexts,
+   Using delay-seconds aligns with `Retry-After`, which is returned in similar contexts,
    eg on 429 responses.
 
-   delta-seconds as defined in {{!CACHING=RFC7234}}, Section 1.2.1 clarifies some parsing rules too.
-
-   Timestamps require a clock synchronization protocol (see {{SEMANTICS}}, Section 4.1.1.1).
+   Timestamps require a clock synchronization protocol 
+   (see {{SEMANTICS}}, Section 5.6.7).
    This may be problematic (eg. clock adjustment, clock skew, failure of hardcoded clock synchronization servers,
    IoT devices, ..).
    Moreover timestamps may not be monotonically increasing due to clock adjustment.
@@ -1194,3 +1194,14 @@ RateLimit-Limit: 100, 100;w=60;burst=1000;comment="sliding window", 5000;w=3600;
     e.g. when they enforce stricter quota-policies,
     or when they are an active component of the service.
     In those case we will consider them as part of the originating infrastructure.
+
+# Changes
+{:numbered="false"}
+
+_RFC Editor: Please remove this section before publication._
+
+## Since draft-ietf-httpapi-ratelimit-headers-00
+{:numbered="false"}
+
+* Use I-D.httpbis-semantics, which includes referencing `delay-seconds`
+  instead of `delta-seconds`. #5

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -163,7 +163,7 @@ The goals do not include:
   Throttling scope:
   : This specification does not cover the throttling scope,
     that may be the given resource-target, its parent path or the whole
-    Origin {{!RFC6454}}, Section 7.
+    Origin (see Section 7 of {{!RFC6454}}).
 
   Response status code:
   : The rate-limit headers may be returned in both
@@ -187,11 +187,11 @@ The goals do not include:
 
 This document uses the Augmented BNF defined in {{!RFC5234}} and updated
 by {{!RFC7405}} along with the "#rule" extension
-defined {{SEMANTICS}}, Section 5.6.1.
+defined in  Section 5.6.1 of {{SEMANTICS}}.
 
-The term Origin is to be interpreted as described in {{!RFC6454}}, Section 7.
+The term Origin is to be interpreted as described in Section 7 of {{!RFC6454}}.
 
-The "delay-seconds" rule is defined in {{SEMANTICS}}, Section 10.2.4.
+The "delay-seconds" rule is defined in Section 10.2.4 of {{SEMANTICS}}.
 
 # Expressing rate-limit policies
 
@@ -359,7 +359,7 @@ The header value is
 The delay-seconds format is used because:
 
 - it does not rely on clock synchronization and is resilient to clock adjustment
-  and clock skew between client and server (see {{SEMANTICS}}, Section 5.6.7);
+  and clock skew between client and server (see Section 5.6.7 of {{SEMANTICS}});
 - it mitigates the risk related to thundering herd when too many clients are serviced with the same timestamp.
 
 This header MUST NOT occur multiple times
@@ -418,7 +418,7 @@ in a trailer section.
 # Intermediaries {#intermediaries}
 
 This section documents the considerations advised in
-{{SEMANTICS}}, Section 16.3.3.
+Section 16.3.3 of {{SEMANTICS}}.
 
 An intermediary that is not part of the originating service infrastructure
 and is not aware of the quota-policy semantic used by the Origin Server
@@ -1090,7 +1090,7 @@ At this point you should stop increasing your request rate.
    eg on 429 responses.
 
    Timestamps require a clock synchronization protocol 
-   (see {{SEMANTICS}}, Section 5.6.7).
+   (see Section 5.6.7 of {{SEMANTICS}}).
    This may be problematic (eg. clock adjustment, clock skew, failure of hardcoded clock synchronization servers,
    IoT devices, ..).
    Moreover timestamps may not be monotonically increasing due to clock adjustment.

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -187,7 +187,7 @@ The goals do not include:
 
 This document uses the Augmented BNF defined in {{!RFC5234}} and updated
 by {{!RFC7405}} along with the "#rule" extension
-defined in  Section 5.6.1 of {{SEMANTICS}}.
+defined in Section 5.6.1 of {{SEMANTICS}}.
 
 The term Origin is to be interpreted as described in Section 7 of {{!RFC6454}}.
 

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -163,7 +163,7 @@ The goals do not include:
   Throttling scope:
   : This specification does not cover the throttling scope,
     that may be the given resource-target, its parent path or the whole
-    Origin {{!RFC6454}} section 7.
+    Origin {{!RFC6454}}, Section 7.
 
   Response status code:
   : The rate-limit headers may be returned in both
@@ -186,12 +186,12 @@ The goals do not include:
 {::boilerplate bcp14}
 
 This document uses the Augmented BNF defined in {{!RFC5234}} and updated
-by {{!RFC7405}} along with the "#rule" extension defined in Section 7 of
-{{!MESSAGING=RFC7230}}.
+by {{!RFC7405}} along with the "#rule" extension
+defined {{!MESSAGING=RFC7230}}, Section 7.
 
-The term Origin is to be interpreted as described in {{!RFC6454}} section 7.
+The term Origin is to be interpreted as described in {{!RFC6454}}, Section 7.
 
-The "delta-seconds" rule is defined in {{CACHING}} section 1.2.1.
+The "delta-seconds" rule is defined in {{CACHING}}, Section 1.2.1.
 
 # Expressing rate-limit policies
 
@@ -359,7 +359,7 @@ The header value is
 The delta-seconds format is used because:
 
 - it does not rely on clock synchronization and is resilient to clock adjustment
-  and clock skew between client and server (see {{SEMANTICS}} Section 4.1.1.1);
+  and clock skew between client and server (see {{SEMANTICS}}, Section 4.1.1.1);
 - it mitigates the risk related to thundering herd when too many clients are serviced with the same timestamp.
 
 This header MUST NOT occur multiple times
@@ -1088,9 +1088,9 @@ At this point you should stop increasing your request rate.
    Using delta-seconds aligns with `Retry-After`, which is returned in similar contexts,
    eg on 429 responses.
 
-   delta-seconds as defined in {{!CACHING=RFC7234}} section 1.2.1 clarifies some parsing rules too.
+   delta-seconds as defined in {{!CACHING=RFC7234}}, Section 1.2.1 clarifies some parsing rules too.
 
-   Timestamps require a clock synchronization protocol (see {{SEMANTICS}} section 4.1.1.1).
+   Timestamps require a clock synchronization protocol (see {{SEMANTICS}}, Section 4.1.1.1).
    This may be problematic (eg. clock adjustment, clock skew, failure of hardcoded clock synchronization servers,
    IoT devices, ..).
    Moreover timestamps may not be monotonically increasing due to clock adjustment.


### PR DESCRIPTION
## This PR

- uses http-core semantics #1 
- fixes Sections refs #4 

Fixes: #1 #4
cc: @reschke