### PR TITLE
Describe RateLimit-Remaining using structured-field-values

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -320,29 +320,33 @@ and can be sent in a trailer section.
 
 ## RateLimit-Remaining {#ratelimit-remaining-header}
 
-The `RateLimit-Remaining` response field indicates the remaining `quota-units` defined in {{request-quota}}
-associated to the client.
+The `RateLimit-Remaining` response field indicates the remaining `quota-units`
+defined in {{request-quota}} associated to the client.
 
-The header value is
+`RateLimit-Remaining` is a Item Structured Field
+{{!I-D.ietf-httpbis-header-structure}}. Its value MUST be an Integer (Section
+3.3.1 of {{I-D.ietf-httpbis-header-structure}}). Its ABNF is:
 
 ~~~
-   RateLimit-Remaining = quota-units
+   RateLimit-Remaining = sf-integer
 ~~~
 
-This header MUST NOT occur multiple times
-and can be sent in a trailer section.
+The value of `RateLimit-Remaining` MUST be non-negative.
+
+`RateLimit-Remaining` MUST NOT occur multiple times. It MAY be sent in a trailer
+section.
+
+For example:
+
+~~~ example
+   RateLimit-Remaining: 50
+~~~
 
 Clients MUST NOT assume that a positive `RateLimit-Remaining` value is
 a guarantee of being served.
 
 A low `RateLimit-Remaining` value is like a yellow traffic-light: the red light
 may arrive suddenly.
-
-One example of `RateLimit-Remaining` use is below.
-
-~~~ example
-   RateLimit-Remaining: 50
-~~~
 
 ## RateLimit-Reset {#ratelimit-reset-header}
 

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -193,7 +193,7 @@ The term Origin is to be interpreted as described in Section 7 of {{!RFC6454}}.
 
 The "delay-seconds" rule is defined in Section 10.2.4 of {{SEMANTICS}}.
 
-This specification uses Structured Headers {{!SF=I-D.ietf-httpbis-header-structure}} to specify syntax.
+This specification uses Structured Headers {{!SF=RFC8941}} to specify syntax.
 The terms sf-list, sf-item, sf-string, sf-token, sf-integer and key refer to the structured types defined therein.
 
 # Expressing rate-limit policies

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -193,7 +193,7 @@ The term Origin is to be interpreted as described in Section 7 of {{!RFC6454}}.
 
 The "delay-seconds" rule is defined in Section 10.2.4 of {{SEMANTICS}}.
 
-This specification uses Structured Headers {{!I-D.ietf-httpbis-header-structure}} to specify syntax.
+This specification uses Structured Headers {{!SF=I-D.ietf-httpbis-header-structure}} to specify syntax.
 The terms sf-list, sf-item, sf-string, sf-token, sf-integer and key refer to the structured types defined therein.
 
 # Expressing rate-limit policies

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -193,6 +193,9 @@ The term Origin is to be interpreted as described in Section 7 of {{!RFC6454}}.
 
 The "delay-seconds" rule is defined in Section 10.2.4 of {{SEMANTICS}}.
 
+This specification uses Structured Headers {{!I-D.ietf-httpbis-header-structure}} to specify syntax.
+The terms sf-list, sf-item, sf-string, sf-token, sf-integer and key refer to the structured types defined therein.
+
 # Expressing rate-limit policies
 
 ## Time window {#time-window}

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -326,15 +326,12 @@ and can be sent in a trailer section.
 The `RateLimit-Remaining` response field indicates the remaining `quota-units` defined in {{request-quota}}
 associated to the client.
 
-`RateLimit-Remaining` is a Item Structured Field
-{{!I-D.ietf-httpbis-header-structure}}. Its value MUST be an Integer (Section
-3.3.1 of {{I-D.ietf-httpbis-header-structure}}). Its ABNF is:
+`RateLimit-Remaining` is an Item {{SF}}.
+Its value MUST be a non-negative Integer.
 
-~~~
+~~~ abnf
    RateLimit-Remaining = sf-integer
 ~~~
-
-The value of `RateLimit-Remaining` MUST be non-negative.
 
 This header MUST NOT occur multiple times
 and can be sent in a trailer section.

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -320,8 +320,8 @@ and can be sent in a trailer section.
 
 ## RateLimit-Remaining {#ratelimit-remaining-header}
 
-The `RateLimit-Remaining` response field indicates the remaining `quota-units`
-defined in {{request-quota}} associated to the client.
+The `RateLimit-Remaining` response field indicates the remaining `quota-units` defined in {{request-quota}}
+associated to the client.
 
 `RateLimit-Remaining` is a Item Structured Field
 {{!I-D.ietf-httpbis-header-structure}}. Its value MUST be an Integer (Section
@@ -333,20 +333,20 @@ defined in {{request-quota}} associated to the client.
 
 The value of `RateLimit-Remaining` MUST be non-negative.
 
-`RateLimit-Remaining` MUST NOT occur multiple times. It MAY be sent in a trailer
-section.
-
-For example:
-
-~~~ example
-   RateLimit-Remaining: 50
-~~~
+This header MUST NOT occur multiple times
+and can be sent in a trailer section.
 
 Clients MUST NOT assume that a positive `RateLimit-Remaining` value is
 a guarantee of being served.
 
 A low `RateLimit-Remaining` value is like a yellow traffic-light: the red light
 may arrive suddenly.
+
+One example of `RateLimit-Remaining` use is below.
+
+~~~ example
+   RateLimit-Remaining: 50
+~~~
 
 ## RateLimit-Reset {#ratelimit-reset-header}
 


### PR DESCRIPTION
From the discussion here:

https://github.com/ietf-wg-httpapi/ratelimit-headers/issues/6#issuecomment-750279717

This PR specifies the RateLimit-Remaining field using some of the language recommended here:

https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-defining-new-structured-fie

To me, the big open question remaining is what this document's stance is on parameters for RateLimit-Remaining. Shall we prohibit them? I'd prefer to say that they are always permitted, and that clients should ignore parameters they don't understand. This is in line with the recommendations in the structured fields document:

> Both Items and Inner Lists allow parameters as an extensibility mechanism; this means that values can later be extended to accommodate more information, if need be. To preserve forward compatibility, field specifications are discouraged from defining the presence of an unrecognized parameter as an error condition.

If we say that parameters are strictly prohibited, then we're cutting ourselves off from having a forward compatibility option, and we're preventing users from coming up with their own extension points.