### PR TITLE
Improve spec goal. See #26

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -150,8 +150,9 @@ The goals of this proposal are:
    2. Improve resiliency of HTTP infrastructures simplifying
       the enforcement and the adoption of rate-limit headers;
 
-   3. Simplify API documentation avoiding expliciting
-      rate-limit fields semantic in documentation.
+   3. Simplify API documentation by eliminating the need
+      to include detailed quota limits
+      and related header fields in API documentation.
 
 The goals do not include:
 

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -148,7 +148,7 @@ The goals of this proposal are:
    1. Standardizing the names and semantics of rate-limit headers
       to ease their enforcement and adoption;
 
-   2. Improve resiliency of HTTP infrastructures
+   2. Improve resiliency of HTTP infrastructure by
       providing clients with information useful
       to throttle their requests and
       prevent 4xx or 5xx responses;

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -145,10 +145,13 @@ using multiple and variable time windows and dynamic quotas, or implementing con
 
 The goals of this proposal are:
 
-   1. Standardizing the names and semantic of rate-limit headers;
+   1. Standardizing the names and semantic of rate-limit headers
+      to ease their enforcement and adoption;
 
-   2. Improve resiliency of HTTP infrastructures simplifying
-      the enforcement and the adoption of rate-limit headers;
+   2. Improve resiliency of HTTP infrastructures
+      providing clients with information useful
+      to throttle their requests and
+      prevent 4xx or 5xx responses;
 
    3. Simplify API documentation by eliminating the need
       to include detailed quota limits

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -145,7 +145,7 @@ using multiple and variable time windows and dynamic quotas, or implementing con
 
 The goals of this proposal are:
 
-   1. Standardizing the names and semantic of rate-limit headers
+   1. Standardizing the names and semantics of rate-limit headers
       to ease their enforcement and adoption;
 
    2. Improve resiliency of HTTP infrastructures


### PR DESCRIPTION
## This PR

Integrate @darrelmiller suggestions in the spec goal

- [x]  Simplify API documentation by eliminating the need to include detailed quota limits and related header fields in API documentation.

