### PR TITLE
Fix: #24. Migration strategy based on servers.

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -308,6 +308,10 @@ moment.
 Nonetheless servers MAY decide to send the `RateLimit` fields
 in a trailer section.
 
+To ease the migration from existing rate limit headers,
+a server SHOULD be able to provide the `RateLimit-Limit` field
+even without the optional `quota-policy` section.  
+
 ## Performance considerations
 
 Servers are not required to return `RateLimit` fields


### PR DESCRIPTION
## This PR

- a server SHOULD be configurable so that it can provide `Limit` with or without `quota-policy`
-  compliant clients have to use SFV parsers
- non-compliant / pre-existing clients can still process fields with quota-policy:off and be migrated in time.


eg..

```
# quota-policy: off
RateLimit-Limit: 100
RateLimit-Remaining: 20
RateLimit-Reset: 12
```

```
# quota-policy: on
RateLimit-Limit: 100,    100;w=20,    200;w=100
RateLimit-Remaining: 20
RateLimit-Reset: 12
```