### PR TITLE
Fix: #94. SF defines whether fields may appear one or more times.

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -215,7 +215,7 @@ The RateLimit-Policy field (see {{ratelimit-policy-field}}), might contain infor
    RateLimit-Limit: 100
 ~~~
 
-This field MUST NOT occur multiple times and can be sent in a trailer section.
+This field can be sent in a trailer section.
 
 ## RateLimit-Policy {#ratelimit-policy-field}
 
@@ -237,7 +237,7 @@ These examples show multiple policies being returned:
    RateLimit-Policy: 10;w=1;burst=1000, 1000;w=3600
 ~~~
 
-This field MUST NOT occur multiple times and can be sent in a trailer section.
+This field can be sent in a trailer section.
 
 ## RateLimit-Remaining {#ratelimit-remaining-field}
 
@@ -267,7 +267,7 @@ The field is a non-negative Integer compatible with the delay-seconds rule, beca
   and clock skew between client and server (see {{Section 5.6.7 of HTTP}});
 - it mitigates the risk related to thundering herd when too many clients are serviced with the same timestamp.
 
-This field MUST NOT occur multiple times and can be sent in a trailer section.
+This field can be sent in a trailer section.
 
 An example of RateLimit-Reset field use is below.
 

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -245,7 +245,7 @@ The "RateLimit-Remaining" field response field indicates the remaining quota uni
 
 The field is an Item and its value is a non-negative Integer expressed in [quota units](#service-limit). Parameters are not allowed.
 
-This field MUST NOT occur multiple times and can be sent in a trailer section.
+This field can be sent in a trailer section.
 
 Clients MUST NOT assume that a positive RateLimit-Remaining field value is a guarantee that further requests will be served.
 


### PR DESCRIPTION
## This PR

According to https://www.rfc-editor.org/rfc/rfc8941.html#section-4.2-7

there is no need to specify that information. Fix: #94 