### PR TITLE
Fix: #95. Remove traffic-light analogy.

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -249,11 +249,7 @@ This field MUST NOT occur multiple times and can be sent in a trailer section.
 
 Clients MUST NOT assume that a positive RateLimit-Remaining field value is a guarantee that further requests will be served.
 
-A low RateLimit-Remaining field value related to
-the number of requests issued in the time window
-or to the request throughput,
-indicates that the server might suddenly
-throttle out the client (see {{providing-ratelimit-fields}}).
+When the value of RateLimit-Remaining is low, it indicates that the server may soon throttle the client (see {{providing-ratelimit-fields}}).
 
 For example:
 

--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -249,7 +249,11 @@ This field MUST NOT occur multiple times and can be sent in a trailer section.
 
 Clients MUST NOT assume that a positive RateLimit-Remaining field value is a guarantee that further requests will be served.
 
-A low RateLimit-Remaining field value is like a yellow traffic-light for either the number of requests issued in the time window or the request throughput: the red light may arrive suddenly (see {{providing-ratelimit-fields}}).
+A low RateLimit-Remaining field value related to
+the number of requests issued in the time window
+or to the request throughput,
+indicates that the server might suddenly
+throttle out the client (see {{providing-ratelimit-fields}}).
 
 For example:
 


### PR DESCRIPTION
Fix #95 