### PR TITLE
Fix formatting of RateLimit dictionary keys

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -208,9 +208,11 @@ The following Keys are defined in this specification:
   limit:
   :  The REQUIRED "limit" key value conveys
      the expiring limit ({{ratelimit-limit-keyword}}).
+  
   remaining:
   :  The OPTIONAL "remaining" key value conveys
      the remaining quota units ({{ratelimit-remaining-keyword}}).
+  
   reset:
   : The REQUIRED "reset" key value conveys
      the time window reset time ({{ratelimit-reset-keyword}}).


### PR DESCRIPTION
Without the extra space between each definition, the next term ends up rendered as part of the previous definition on https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-07#section-3.1

This is what it currently looks like:
![before](https://github.com/ietf-wg-httpapi/ratelimit-headers/assets/114976/0d667f62-d11b-4334-ae95-58b7eccc87d4)

This is what a local build looks like after this change (I'm not sure why the font is different, but you can see that the definition list is correctly laid out):
![after](https://github.com/ietf-wg-httpapi/ratelimit-headers/assets/114976/613b1057-46d6-4401-82c0-a407eea89968)
