### PR TITLE
Add missing quota unit to registry

### DIFF
--- a/draft-ietf-httpapi-ratelimit-headers.md
+++ b/draft-ietf-httpapi-ratelimit-headers.md
@@ -514,6 +514,7 @@ The registry has the following initial content:
 |---------------------|-----------|---------------|
 | request             | {{&SELF}} |               |
 | content-bytes       | {{&SELF}} |               |
+| concurrent-requests | {{&SELF}} |               |
 |---------------------|-----------|---------------|
 
 ### Registration Template


### PR DESCRIPTION
This unit is defined in https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-08.html#name-quota-unit-parameter but not mentioned in the unit registry.